### PR TITLE
Using ThreadPool and watchers' finish

### DIFF
--- a/lib/topological_inventory/openshift/collectors_pool.rb
+++ b/lib/topological_inventory/openshift/collectors_pool.rb
@@ -3,8 +3,64 @@ require "topological_inventory/openshift/collector"
 require "topological_inventory/openshift/logging"
 
 module TopologicalInventory::Openshift
+  # Collector pool for openshift cannot interrupt collector due to watches at this moment
+  # So there can't be queue with FixedThreadPool
+  # !!!
+  # *IMPORTANT* doesn't have constant memory usage with increasing number of sources
+  # !!!
   class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
+
+    def initialize(config_name, metrics)
+      super
+      self.collectors  = {}
+      self.thread_pool = Concurrent::CachedThreadPool.new
+    end
+
+    def run!
+      loop do
+        reload_config
+        reload_secrets
+
+        # Secret is deployed just after config,
+        # so we should wait for it
+        if secrets_newer_than_config?
+          remove_old_collectors
+          add_new_collectors
+        end
+
+        sleep(10)
+      end
+    end
+
+    protected
+
+    def add_new_collectors
+      ::Settings.sources.to_a.each do |source|
+        next unless collectors[source.source].nil?
+        next if (source_secret = secrets_for_source(source)).nil?
+
+        # Check if necessary endpoint/auth data are not blank (provider specific)
+        next unless source_valid?(source, source_secret)
+
+        collector = new_collector(source, source_secret)
+        collectors[source.source] = collector
+
+        thread_pool.post do
+          collector.collect!
+        end
+      end
+    end
+
+    def remove_old_collectors
+      requested_uids = ::Settings.sources.to_a.collect(&:source)
+      existing_uids  = collectors.keys
+
+      (existing_uids - requested_uids).each do |source_uid|
+        collector = collectors.delete(source_uid)
+        collector&.stop
+      end
+    end
 
     def path_to_config
       File.expand_path("../../../config", File.dirname(__FILE__))

--- a/spec/topological_inventory/openshift/collectors_pool_spec.rb
+++ b/spec/topological_inventory/openshift/collectors_pool_spec.rb
@@ -1,5 +1,10 @@
 RSpec.describe TopologicalInventory::Openshift::CollectorsPool do
   let(:source) { double("Source") }
+  let(:source1) { {:source => '42b1893c-ebbd-44e9-89b1-5c29b5fe6e10', :schema => 'http', :host => 'cloud.redhat.com', :port => 80} }
+  let(:source2) { {:source => 'fe8bcaea-3670-42c7-bed9-71f6e0bceadd', :schema => 'https', :host => 'cloud.redhat.com', :port => 443} }
+  let(:source3) { {:source => '05838743-4285-404a-b4d6-294045c0d4be', :schema => 'xxx', :host => 'cloud.redhat.com', :port => 1234} }
+  let(:source4) { {:source => '5ed08a3c-3de4-4a90-8ce9-e0f724b2b2e6', :schema => 'xxx', :host => 'cloud.redhat.com', :port => 1234} }
+  let(:sources) { [source1, source2, source3] }
 
   subject { described_class.new(nil, nil) }
 
@@ -11,8 +16,116 @@ RSpec.describe TopologicalInventory::Openshift::CollectorsPool do
                                           :host   => data[1])
         secret = { "username" => nil, "password" => data[2] }
 
-        expect(subject.source_valid?(source, secret)).to eq(nil_index == -1)
+        expect(subject.send(:source_valid?, source, secret)).to eq(nil_index == -1)
       end
+    end
+  end
+
+  context "add or remove collector" do
+    before do
+      ::Config.load_and_set_settings('some-value-needed.txt')
+      @collector = double("collector")
+      allow(subject).to receive(:new_collector).and_return(@collector)
+    end
+
+    context "without secrets check" do
+      before do
+        allow(subject).to receive(:secrets_for_source).and_return({})
+        allow(subject).to receive(:source_valid?).and_return(true)
+      end
+
+      it "adds new collectors from settings" do
+        allow(@collector).to receive(:collect!).and_return(nil)
+        expect(@collector).to receive(:collect!).exactly(sources.size).times
+
+        sources.each do |source|
+          stub_settings_merge(:sources => ::Settings.sources.to_a + [source])
+
+          subject.send(:add_new_collectors)
+
+          saved_collectors = subject.send(:collectors)
+          expect(saved_collectors[source[:source]]).to eq(@collector)
+        end
+        subject.send(:thread_pool).shutdown
+        subject.send(:thread_pool).wait_for_termination
+        expect(subject.send(:collectors).keys).to eq(sources.collect { |s| s[:source] })
+      end
+
+      it "removes existing collectors missing in settings" do
+        mutex = Mutex.new
+        cv = ConditionVariable.new
+        i = 0
+
+        allow(@collector).to receive(:collect!) { mutex.synchronize { i += 1; cv.wait(mutex) } }
+        allow(@collector).to receive(:stop)
+
+        # sources.size - new_sources.size == 2
+        expect(@collector).to receive(:stop).twice
+
+        stub_settings_merge(:sources => sources)
+        subject.send(:add_new_collectors)
+
+        # Wait for all threads are collecting
+        init = false
+        until init
+          mutex.synchronize { init = i == sources.size }
+        end
+
+        # Set new config
+        new_sources = [source1]
+        stub_settings_merge(:sources => new_sources)
+
+        threads = subject.send(:thread_pool)
+        subject.send(:remove_old_collectors)
+
+        # Wait for all collecting is complete (rspec can throw error otherwise)
+        mutex.synchronize { cv.broadcast }
+        #threads.each_value(&:join)
+        threads.shutdown
+        threads.wait_for_termination
+
+        expect(subject.send(:collectors).keys).to eq(new_sources.collect { |s| s[:source] })
+      end
+    end
+
+    context "with secrets check" do
+      let(:secrets) do
+        { 'updated_at' => Time.now.to_s,
+          source1[:source] => { 'username' => 'admin1', 'password' => 'password1' },
+          source2[:source] => { 'username' => 'admin2', 'password' => 'password2' },
+          'unknown' => { 'username' => 'admin3', 'password' => 'password3' }
+        }
+      end
+      before do
+        allow(@collector).to receive(:collect!).and_return(nil)
+      end
+
+      it "creates only collectors found in both secret and config" do
+        # 4 sources in yaml config
+        stub_settings_merge(:sources => sources + [source4])
+        # 3 sources in secret
+        allow(subject).to receive(:secrets).and_return(secrets)
+
+        # for each source in yaml secret is searched (4x)
+        expect(subject).to receive(:secrets_for_source).and_call_original.exactly(4).times
+        # only 2 corresponding
+        expect(@collector).to receive(:collect!).exactly(2).times
+
+        subject.send(:add_new_collectors)
+
+        subject.send(:thread_pool).shutdown
+        subject.send(:thread_pool).wait_for_termination
+
+        expected_uids = [source1, source2].collect {|s| s[:source]}
+        expect(subject.send(:collectors).keys).to eq(expected_uids)
+      end
+    end
+  end
+
+  def stub_settings_merge(hash)
+    if defined?(::Settings)
+      Settings.add_source!(hash)
+      Settings.reload!
     end
   end
 end


### PR DESCRIPTION
`FixedThreadPool` used in https://github.com/RedHatInsights/topological_inventory-providers-common/pull/11 cannot be used by current implementation because watchers have to be interrupted and resourceVersion saved. 
Instead of it `CachedThreadPool` is used. 
So OpenShift sources per collector number cannot be increased now. 