### PR TITLE
Bump providers-common to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "ma
 gem "manageiq-loggers", "~> 0.4.0", ">= 0.4.2"
 gem "manageiq-messaging", "~> 0.1.2"
 gem "sources-api-client", "~> 1.0"
-gem 'topological_inventory-api-client',         "~> 2.0"
-gem "topological_inventory-ingress_api-client", "~> 1.0"
-gem "topological_inventory-providers-common", "~> 0.1"
+gem 'topological_inventory-api-client',         "~> 3.0"
+gem "topological_inventory-ingress_api-client", "~> 1.0.1"
+gem "topological_inventory-providers-common", "~> 1.0.0"
 
 group :development, :test do
   gem "rspec"

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
     end
 
     let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
-    let(:base_url_path) { "https://cloud.redhat.com/api/topological-inventory/v2.0/" }
+    let(:base_url_path) { "https://cloud.redhat.com/api/topological-inventory/v3.0/" }
     let(:service_plan_url) { URI.join(base_url_path, "service_plans/#{service_plan.id}").to_s }
     let(:source_url) { URI.join(base_url_path, "sources/#{source.id}").to_s }
     let(:service_offering_url) { URI.join(base_url_path, "service_offerings/#{service_offering.id}").to_s }


### PR DESCRIPTION
- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/16 
  - **[ requires RubyGems release - v1.0.0 ]**