### PR TITLE
Reduce the timeout to open a connection to 10 sec

### DIFF
--- a/lib/topological_inventory/openshift/connection.rb
+++ b/lib/topological_inventory/openshift/connection.rb
@@ -4,20 +4,23 @@ require "active_support/core_ext/numeric/time"
 
 module TopologicalInventory::Openshift
   class Connection
+    OPEN_TIMEOUT_SECONDS = 10.freeze
+    ENDPOINT_RETRY_MINUTES = 60.freeze
+
     def initialize
       @connection_failure_time = {}
     end
 
-    def connect(endpoint_type, host:, port: 8443, token:, verify_ssl: OpenSSL::SSL::VERIFY_NONE, endpoint_retry_minutes: 60)
+    def connect(endpoint_type, host:, port: 8443, token:, verify_ssl: OpenSSL::SSL::VERIFY_NONE, endpoint_retry_minutes: ENDPOINT_RETRY_MINUTES, open_timeout: OPEN_TIMEOUT_SECONDS)
       raise "Invalid endpoint type: #{endpoint_type}" unless valid_endpoint_types.include?(endpoint_type)
 
       last_failure_time = connection_failure_time[endpoint_type]
       return if last_failure_time && last_failure_time > endpoint_retry_minutes.minutes.ago.utc
 
       params = connect_params(endpoint_type)
-      params.merge!(:host => host, :port => port, :token => token, :verify_ssl => verify_ssl)
+      params.merge!(:host => host, :port => port, :token => token, :verify_ssl => verify_ssl, :open_timeout => open_timeout)
 
-      open(*params.values_at(:host, :port, :path, :api_version, :token, :verify_ssl))
+      open(*params.values_at(:host, :port, :path, :api_version, :token, :verify_ssl, :open_timeout))
     rescue StandardError => err
       connection_failure_time[endpoint_type] = Time.now.utc
       raise
@@ -42,12 +45,13 @@ module TopologicalInventory::Openshift
       end
     end
 
-    def open(host, port, path, api_version, token, verify_ssl)
+    def open(host, port, path, api_version, token, verify_ssl, open_timeout)
       endpoint_uri = URI::HTTPS.build(:host => host, :port => port, :path => path)
 
       options = {
         :ssl_options  => {:verify_ssl => verify_ssl},
-        :auth_options => {:bearer_token => token}
+        :auth_options => {:bearer_token => token},
+        :timeouts     => {:open => open_timeout}
       }
 
       Kubeclient::Client.new(endpoint_uri, api_version, options).tap(&:discover)


### PR DESCRIPTION
If an attempt to connect to an OpenShift source hangs the default
open_timeout of 60 seconds was starving the operations worker causing
big kafka lag.

Should be solved by this PR, [autoscaler](https://github.com/RedHatInsights/topological_inventory-orchestrator/pull/81) and https://github.com/RedHatInsights/sources-api/issues/206

https://www.rubydoc.info/gems/kubeclient/3.0.0#timeouts

based on
- [TPINVTRY-851](https://projects.engineering.redhat.com/browse/TPINVTRY-851)
- https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/62

---

[TPINVTRY-946](https://projects.engineering.redhat.com/browse/TPINVTRY-946)
