### PR TITLE
remove argument to `connection_check` since common doesn't pass it anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "rake", ">= 12.3.3"
 
 gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "master"
 gem "manageiq-loggers", "~> 0.5.0"
-gem "manageiq-messaging", "~> 0.1.2"
+gem "manageiq-messaging", "~> 0.1.5"
 gem "sources-api-client", "~> 3.0"
 gem 'topological_inventory-api-client',         "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -17,7 +17,7 @@ module TopologicalInventory
 
         private
 
-        def connection_check(source_id)
+        def connection_check
           connection_manager = TopologicalInventory::Openshift::Connection.new
           connection_manager.connect("openshift", :host => endpoint.host, :port => endpoint.port, :token => authentication.password)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1854107

When looking into this BZ I found that the `connection_check` method in operations/source.rb was not updated yet - we saw this with azure/amazon as well.
