### PR TITLE
Add HealthCheck operation after message process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "manageiq-messaging", "~> 0.1.5"
 gem "sources-api-client", "~> 3.0"
 gem 'topological_inventory-api-client',         "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.9"
+gem "topological_inventory-providers-common", "~> 1.0.10"
 
 group :development, :test do
   gem "rspec"

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -3,6 +3,7 @@ require "sources-api-client"
 require "topological_inventory/openshift/logging"
 require "topological_inventory/openshift/operations/processor"
 require "topological_inventory-api-client"
+require "topological_inventory/providers/common/operations/health_check"
 
 module TopologicalInventory
   module Openshift
@@ -24,6 +25,7 @@ module TopologicalInventory
           client.subscribe_topic(queue_opts) do |message|
             process_message(message)
             client.ack(message.ack_ref)
+            TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
           end
         ensure
           client&.close


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-1055

I am going to add a  to the deployment template that will check if the file has been touched for the last 2 hours, if it has not then OCP will restart the pod for us.

DEPENDS ON:
- [x] [Health Check File Added](https://github.com/RedHatInsights/topological_inventory-providers-common/pull/48)
- [x] [Provider-common gem released](https://github.com/RedHatInsights/topological_inventory-providers-common/pull/49)