### PR TITLE
Rubocop rules from insights-api-common + yamllint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -28,4 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: rubocop-0-69
+    channel: rubocop-1-0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+ignore: |
+
+extends: relaxed
+
+rules:
+  line-length:
+    max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,9 @@ gem "topological_inventory-providers-common", "~> 1.0.10"
 
 group :development, :test do
   gem "rspec"
-  gem 'rubocop',             "~>0.69.0", :require => false
-  gem 'rubocop-performance', "~>1.3",    :require => false
+  gem "rubocop",             "~> 1.0.0", :require => false
+  gem "rubocop-performance", "~> 1.8",   :require => false
+  gem "rubocop-rails",       "~> 2.8",   :require => false
   gem "simplecov",           "~>0.17.1"
   gem "webmock"
 end


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
