### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-openshift.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-openshift)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-openshift.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-openshift)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fc6eda966102ef7b319d/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-openshift/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fc6eda966102ef7b319d/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-openshift/test_coverage)
 [![Security](https://hakiri.io/github/RedHatInsights/topological_inventory-openshift/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-openshift/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.