### PR TITLE
Bump Providers-Common to 2.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "manageiq-messaging", "~> 1.0.0"
 gem "sources-api-client", "~> 3.0"
 gem 'topological_inventory-api-client',         "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 2.1.2"
+gem "topological_inventory-providers-common", "~> 2.1.3"
 
 group :development, :test do
   gem "rspec"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/sources-api/issues/286

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/70

---

[RHCLOUD-10879](https://issues.redhat.com/browse/RHCLOUD-10879)