### PR TITLE
Lock RH gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,12 @@ gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 
 gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "master"
-gem "manageiq-loggers", "~> 0.5.0"
-gem "manageiq-messaging", "~> 1.0.0"
-gem "sources-api-client", "~> 3.0"
-gem 'topological_inventory-api-client',         "~> 3.0"
-gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 2.1.5"
+gem "manageiq-loggers", "0.5.0"
+gem "manageiq-messaging", "1.0.1"
+gem "sources-api-client", "3.0.0"
+gem "topological_inventory-api-client",         "3.0.1"
+gem "topological_inventory-ingress_api-client", "1.0.4"
+gem "topological_inventory-providers-common", "2.1.5"
 
 group :development, :test do
   gem "rspec"


### PR DESCRIPTION
OpenShift collector/operations is not actively developed at this moment, so we can freeze our gems in Gemfile

---

[RHCLOUD-10835](https://issues.redhat.com/browse/RHCLOUD-10835)