### PR TITLE
Forward logs to STDERR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN echo "gem: --no-document" > ~/.gemrc && \
 COPY . $WORKDIR
 
 RUN chgrp -R 0 $WORKDIR && \
-    chmod -R g=u $WORKDIR
+    chmod -R g=u $WORKDIR \
+    curl -L -o /usr/bin/haberdasher \
+    https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
+    chmod 755 /usr/bin/haberdasher
 
-ENTRYPOINT ["bin/openshift-collector"]
+ENTRYPOINT ["/usr/bin/haberdasher"]
+CMD ["bin/openshift-collector"]

--- a/lib/topological_inventory/openshift/logging.rb
+++ b/lib/topological_inventory/openshift/logging.rb
@@ -2,12 +2,42 @@ require "topological_inventory/providers/common/logging"
 
 module TopologicalInventory
   module Openshift
+    APP_NAME = "topological-inventory-openshift-operations".freeze
+
     class << self
       attr_writer :logger
     end
 
+    class Formatter < ManageIQ::Loggers::Container::Formatter
+      def call(severity, time, progname, msg)
+        payload = {
+          :"ecs.version" => "1.5.0",
+          :@timestamp    => format_datetime(time),
+          :hostname      => hostname,
+          :pid           => $PROCESS_ID,
+          :tid           => thread_id,
+          :service       => progname,
+          :level         => translate_error(severity),
+          :message       => prefix_task_id(msg2str(msg)),
+          :request_id    => request_id,
+          :tags          => [APP_NAME],
+          :labels        => {"app" => APP_NAME}
+        }.compact
+        JSON.generate(payload) << "\n"
+      end
+    end
+
+    def self.log_to_stderr?
+      ENV['LOG_HANDLER'] == "haberdasher"
+    end
+
     def self.logger
-      @logger ||= TopologicalInventory::Providers::Common::Logger.new
+      @logger ||= begin
+                    provider_logger = TopologicalInventory::Providers::Common::Logger.new
+                    provider_logger.reopen(STDERR) if log_to_stderr?
+                    provider_logger.formatter = Formatter.new
+                    provider_logger
+                  end
     end
 
     module Logging

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -17,11 +17,24 @@ module TopologicalInventory
         end
 
         def run
-          logger.info("Topological Inventory Openshift Operations worker started...")
+          logger.info("[STDERR-INFO] Topological Inventory Openshift Operations worker started...")
+          logger.warn("[STDERR-WARN] Topological Inventory Openshift Operations worker started...")
+          logger.debug("[STDERR-DEBUG] Topological Inventory Openshift Operations worker started...")
+          logger.error("[STDERR-ERROR] Topological Inventory Openshift Operations worker started...")
 
+          raise StandardError, "This is standard and simulated error."
+        rescue => e
+          logger.error("#{e}\n#{e.backtrace.join("\n")}")
+        ensure
+          original_run
+        end
+
+        def original_run
           client.subscribe_topic(queue_opts) do |message|
             process_message(message)
           end
+        rescue => e
+          logger.error("#{e}\n#{e.backtrace.join("\n")}")
         ensure
           client&.close
         end


### PR DESCRIPTION
- temporar change to test haberdasher and sending logs thought Kafka to could watch 
- added more logs messages only for testing reasons
- how to test locally https://github.com/RedHatInsights/topological_inventory-guides/pull/47
- [ ] e2e - https://github.com/RedHatInsights/e2e-deploy/pull/2950
  -  `LOG_HANDLER` is control variable to determine whether send logs to standard error(for haberdasher) or to use built-in(original solution - sending to cloud watch) logger 
      - = haberdasher =  send logs to standard error
      -=  built-in  - original solution

cc @lindgrenj6 @slemrmartin 

### Links
https://issues.redhat.com/browse/RHCLOUD-13173
