### PR TITLE
Use insights-loggers-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "activesupport", '~> 5.2.4.3'
-gem "cloudwatchlogger", "~> 0.2.1"
 gem "concurrent-ruby"
 gem "http", "~> 4.1.1"
 gem "more_core_extensions"
@@ -13,12 +12,13 @@ gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 
 gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "master"
-gem "manageiq-loggers", "0.5.0"
+
 gem "manageiq-messaging", "1.0.1"
 gem "sources-api-client", "3.0.0"
 gem "topological_inventory-api-client",         "3.0.1"
 gem "topological_inventory-ingress_api-client", "1.0.4"
-gem "topological_inventory-providers-common", "2.1.5"
+gem "topological_inventory-providers-common", "~> 3.0.1"
+gem "insights-loggers-ruby", "0.1.6"
 
 group :development, :test do
   gem "rspec"

--- a/lib/topological_inventory/openshift/logging.rb
+++ b/lib/topological_inventory/openshift/logging.rb
@@ -1,4 +1,4 @@
-require "topological_inventory/providers/common/logging"
+require "insights/loggers"
 
 module TopologicalInventory
   module Openshift
@@ -8,36 +8,16 @@ module TopologicalInventory
       attr_writer :logger
     end
 
-    class Formatter < ManageIQ::Loggers::Container::Formatter
-      def call(severity, time, progname, msg)
-        payload = {
-          :"ecs.version" => "1.5.0",
-          :@timestamp    => format_datetime(time),
-          :hostname      => hostname,
-          :pid           => $PROCESS_ID,
-          :tid           => thread_id,
-          :service       => progname,
-          :level         => translate_error(severity),
-          :message       => prefix_task_id(msg2str(msg)),
-          :request_id    => request_id,
-          :tags          => [APP_NAME],
-          :labels        => {"app" => APP_NAME}
-        }.compact
-        JSON.generate(payload) << "\n"
+    def self.logger_class
+      if ENV['LOG_HANDLER'] == "haberdasher"
+        "Insights::Loggers::StdErrorLogger"
+      else
+        "TopologicalInventory::Providers::Common::Logger"
       end
     end
 
-    def self.log_to_stderr?
-      ENV['LOG_HANDLER'] == "haberdasher"
-    end
-
     def self.logger
-      @logger ||= begin
-                    provider_logger = TopologicalInventory::Providers::Common::Logger.new
-                    provider_logger.reopen(STDERR) if log_to_stderr?
-                    provider_logger.formatter = Formatter.new
-                    provider_logger
-                  end
+      @logger ||= Insights::Loggers::Factory.create_logger(logger_class, :app_name => APP_NAME)
     end
 
     module Logging


### PR DESCRIPTION
This PR replaces `manageiq-loggers` gem with [insights-loggers-ruby](https://github.com/RedHatInsights/insights-loggers-ruby) gem, usage is mentioned in readme of the repo's gem.

### Links
https://issues.redhat.com/browse/RHCLOUD-13925

