### PR TITLE
Extend logging methods for StdErrorLogger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "sources-api-client", "3.0.0"
 gem "topological_inventory-api-client",         "3.0.1"
 gem "topological_inventory-ingress_api-client", "1.0.4"
 gem "topological_inventory-providers-common", "~> 3.0.1"
-gem "insights-loggers-ruby", "0.1.6"
+gem "insights-loggers-ruby", "0.1.8"
 
 group :development, :test do
   gem "rspec"

--- a/lib/topological_inventory/openshift/logging.rb
+++ b/lib/topological_inventory/openshift/logging.rb
@@ -17,7 +17,13 @@ module TopologicalInventory
     end
 
     def self.logger
-      @logger ||= Insights::Loggers::Factory.create_logger(logger_class, :app_name => APP_NAME)
+      log_params = {:app_name => APP_NAME}
+
+      if logger_class == "Insights::Loggers::StdErrorLogger"
+        log_params[:extend_module] = "TopologicalInventory::Providers::Common::LoggingFunctions"
+      end
+
+      @logger ||= Insights::Loggers::Factory.create_logger(logger_class, log_params)
     end
 
     module Logging

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -17,6 +17,7 @@ module TopologicalInventory
         end
 
         def run
+          logger.availability_check("STDERRCHECK")
           logger.info("[STDERR-INFO] Topological Inventory Openshift Operations worker started...")
           logger.warn("[STDERR-WARN] Topological Inventory Openshift Operations worker started...")
           logger.debug("[STDERR-DEBUG] Topological Inventory Openshift Operations worker started...")


### PR DESCRIPTION
This uses ability to add logger methods from modules for StdErrorLogger.

[This methods](https://github.com/RedHatInsights/topological_inventory-providers-common/blob/7d9af7e44668b18f4164397eecbadf7da2735036/lib/topological_inventory/providers/common/logging.rb) are required for openshift operations


cc @slemrmartin 

